### PR TITLE
feature: crawl sitemaps in spider mode

### DIFF
--- a/greenflare/core/gflarecrawler.py
+++ b/greenflare/core/gflarecrawler.py
@@ -327,7 +327,7 @@ class GFlareCrawler:
                 url, allow_redirects=True, timeout=timeout)
 
             content_type = header.headers.get('content-type', '')
-            if 'text' in content_type:
+            if ('text' in content_type) or ('application/xml' in content_type):
                 body = self.session.get(
                     url, allow_redirects=True, timeout=timeout)
                 return body

--- a/greenflare/core/gflareresponse.py
+++ b/greenflare/core/gflareresponse.py
@@ -64,7 +64,8 @@ class GFlareResponse:
             'h2': '//h2/text()',
             'page_title': '/html/head/title/text()',
             'meta_description': '/html/head/meta[@name="description"]/@content',
-            'base_url': '/html/head/base/@href'
+            'base_url': '/html/head/base/@href',
+            'xml_loc': '//loc[parent::url|parent::sitemap]/text()'
         }
 
         self.xpath_link_extraction = self.get_link_extraction_xpath()
@@ -131,6 +132,8 @@ class GFlareResponse:
             xpaths.append(self.xpath_mapping['stylesheets'])
         if 'javascript' in crawl_items:
             xpaths.append(self.xpath_mapping['javascript'])
+        if 'xml_loc' in crawl_items:
+            xpaths.append(self.xpath_mapping['xml_loc'])
 
         return '|'.join(xpaths)
 

--- a/greenflare/widgets/settingstab.py
+++ b/greenflare/widgets/settingstab.py
@@ -179,7 +179,7 @@ class SettingsTab(ttk.Frame):
 
         # Links Group
         self.checkboxgroup_links = CheckboxGroup(self.frame_second, 'Links', [
-            'Canonicals', 'Pagination', 'Hreflang', 'External Links'], self.crawler.settings, 'CRAWL_ITEMS')
+            'Canonicals', 'Pagination', 'Hreflang', 'External Links', 'XML loc'], self.crawler.settings, 'CRAWL_ITEMS')
         self.checkboxgroup_links.pack(**self.group_args)
 
         # # Directives Group


### PR DESCRIPTION
Resolves #9 

Adds an "XML Loc" checkbox to the settings tab. When selected and using spider mode, crawler will read the text from sitemap `<loc>` tags, and append to list of paths. Functionally, this adds the ability to use a `/sitemap.xml` or `/sitemap-index.xml` path as a seed URL.